### PR TITLE
Update removeAll function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-jquery.sumoselect
+jquery.sumoselect (FORK)
 =============
+
+__!!! Why use this fork?__ The original [jquery.sumoselect](https://github.com/HemantNegi/jquery.sumoselect) is no longer maintained. This fork just adds 2 commits on top of the latest version to fix a [XSS issue](https://github.com/HemantNegi/jquery.sumoselect/pull/288).
 
 
 jquery.sumoselect.js - A beautiful cross device Single/Multi Select jQuery Select plugin.

--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -738,12 +738,15 @@
                 },
 
                 // removes all but the selected one
-                removeAll: function () {
+                // if force argument is provided, then will be deleted selected value too
+                removeAll: function (force = false) {
                     var O = this;
                     var options = O.E.find('option');
 
+                    if (typeof force !== 'boolean') throw 'force must be a boolean value'
+
                     for (var x = (options.length - 1); x >= 0; x--) {
-                        if (options[x].selected !== true) {
+                        if (force || options[x].selected !== true) {
                             O.remove(x);
                         }
                     }


### PR DESCRIPTION
In the case with Stuart bridge I faced the problem, when I have select `Country`, I must make options in the second select `City` according to selected option in `Country`, but the problem is what in default behaviour, `removeAll()` will not delete selected option, I have to do it manually – remove whole select from DOM and create it one more time..., so I a little bit monkey-patched function.